### PR TITLE
close the invalid connection

### DIFF
--- a/ccore/nebula/driver.go
+++ b/ccore/nebula/driver.go
@@ -89,13 +89,13 @@ func (d *driverGraph) open(driver types.Driver) error {
 	}
 
 	if err = graphClientDriver.VerifyClientVersion(); err != nil {
-		graphClientDriver.Close()
+		_ = graphClientDriver.Close()
 		return err
 	}
 
 	resp, err := graphClientDriver.Authenticate(d.username, d.password)
 	if err != nil {
-		graphClientDriver.Close()
+		_ = graphClientDriver.Close()
 		return err
 	}
 
@@ -135,6 +135,7 @@ func (d *driverMeta) open(driver types.Driver) error {
 	}
 
 	if err = metaClientDriver.VerifyClientVersion(); err != nil {
+		_ = metaClientDriver.Close()
 		return err
 	}
 

--- a/ccore/nebula/driver.go
+++ b/ccore/nebula/driver.go
@@ -89,11 +89,13 @@ func (d *driverGraph) open(driver types.Driver) error {
 	}
 
 	if err = graphClientDriver.VerifyClientVersion(); err != nil {
+		graphClientDriver.Close()
 		return err
 	}
 
 	resp, err := graphClientDriver.Authenticate(d.username, d.password)
 	if err != nil {
+		graphClientDriver.Close()
 		return err
 	}
 


### PR DESCRIPTION
close the graph client if there's a `verifyclient` or `auth` error.
reduce the invalid connection.