### PR TITLE
Error in README.md document, correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ response:
 #### Disconnect API ####
 
 ```bash
-$ curl -X POST http://127.0.0.1:8080/api/db/disconnect
+$ curl -X POST -H "Cookie:common-nsid=bec2e665ba62a13554b617d70de8b9b9" http://127.0.0.1:8080/api/db/disconnect
 ```
 
 response:


### PR DESCRIPTION
To exit the connection, add common nsid to the request header cookie. If not, the following error will be prompted:
{
  "code": -1,
  "data": null,
  "message": "No connection existed"
}